### PR TITLE
Fix agent imports and add mock subject API

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,0 +1,2 @@
+"""API utilities for the AutoGen service."""
+

--- a/api/mock_api.py
+++ b/api/mock_api.py
@@ -1,0 +1,53 @@
+"""Simple FastAPI application exposing subject data.
+
+This mock API allows clients to retrieve basic information about
+available subjects, their syllabi, learning materials and quizzes.
+"""
+
+from pathlib import Path
+
+from fastapi import FastAPI, HTTPException
+
+from data.data_loader import SubjectDataLoader
+
+
+app = FastAPI(title="Mock Subject Data API")
+
+data_loader = SubjectDataLoader(base_path=Path(__file__).resolve().parent.parent / "data")
+
+
+@app.get("/subjects")
+def list_subjects() -> dict:
+    """Return all available subjects."""
+    return {"subjects": data_loader.subjects}
+
+
+@app.get("/subjects/{subject}/syllabus")
+def get_syllabus(subject: str) -> dict:
+    """Return the syllabus for a given subject."""
+    subject = subject.lower()
+    if subject not in data_loader.subjects:
+        raise HTTPException(status_code=404, detail="Subject not found")
+    return data_loader.load_syllabus(subject)
+
+
+@app.get("/subjects/{subject}/materials")
+def get_materials(subject: str) -> dict:
+    """Return learning materials for a given subject."""
+    subject = subject.lower()
+    if subject not in data_loader.subjects:
+        raise HTTPException(status_code=404, detail="Subject not found")
+    return {"materials": data_loader.load_materials(subject)}
+
+
+@app.get("/subjects/{subject}/quizzes")
+def get_quizzes(subject: str) -> dict:
+    """Return quiz questions for a given subject."""
+    subject = subject.lower()
+    if subject not in data_loader.subjects:
+        raise HTTPException(status_code=404, detail="Subject not found")
+    return {"quizzes": data_loader.load_quizzes(subject)}
+
+
+__all__ = ["app"]
+

--- a/config/agents/__init__.py
+++ b/config/agents/__init__.py
@@ -1,0 +1,34 @@
+"""Agents package for the AutoGen Education Service.
+
+This package provides backwards‑compatibility wrappers around agent
+classes defined at the project root. It also exposes subject expert
+agents to mirror the expected ``agents`` package layout.
+"""
+
+from __future__ import annotations
+
+from .base_agent import BaseAgent, SubjectExpertAgent  # noqa: F401
+from .info_agent import InfoAgent  # noqa: F401
+
+# Import subject experts into the package namespace for convenience
+from .subject_experts.cs_expert import CSExpertAgent
+from .subject_experts.math_expert import MathExpertAgent
+from .subject_experts.english_expert import EnglishExpertAgent
+from .subject_experts.biology_expert import BiologyExpertAgent
+from .subject_experts.physics_expert import PhysicsExpertAgent
+from .subject_experts.chemistry_expert import ChemistryExpertAgent
+from .subject_experts.literature_expert import LiteratureExpertAgent
+
+__all__ = [
+    "BaseAgent",
+    "InfoAgent",
+    "CSExpertAgent",
+    "MathExpertAgent",
+    "PhysicsExpertAgent",
+    "SubjectExpertAgent",
+    "BiologyExpertAgent",
+    "EnglishExpertAgent",
+    "ChemistryExpertAgent",
+    "LiteratureExpertAgent",
+]
+

--- a/config/agents/info_agent.py
+++ b/config/agents/info_agent.py
@@ -2,10 +2,10 @@
 Information Agent for retrieving subject materials
 """
 import json
-import os
 from typing import Dict, Any, List, Optional
 from pathlib import Path
-from agents.base_agent import BaseAgent
+
+from .base_agent import BaseAgent
 from config.settings import settings
 
 class InfoAgent(BaseAgent):

--- a/config/agents/subject_experts/__init__.py
+++ b/config/agents/subject_experts/__init__.py
@@ -1,37 +1,20 @@
-"""
-Agents package for the AutoGen Education Service.
+"""Subject expert agent implementations."""
 
-This package provides backwards‑compatibility wrappers around agent
-classes defined at the project root.  It also organizes subject
-expert agents under the ``subject_experts`` subpackage to mirror the
-expected structure.  Importing from ``agents.base_agent`` or
-``agents.subject_experts.math_expert`` will forward to the
-corresponding module at the project root.
-"""
-
-from __future__ import annotations
-
-from .base_agent import BaseAgent, SubjectExpertAgent  # noqa: F401
-from .info_agent import InfoAgent  # noqa: F401
-
-# Import subject experts into the package namespace for convenience
-from .subject_experts.cs_expert import CSExpertAgent
-from .subject_experts.math_expert import MathExpertAgent
-from .subject_experts.english_expert import EnglishExpertAgent
-from .subject_experts.biology_expert import BiologyExpertAgent
-from .subject_experts.physics_expert import PhysicsExpertAgent
-from .subject_experts.chemistry_expert import ChemistryExpertAgent
-from .subject_experts.literature_expert import LiteratureExpertAgent 
+from .biology_expert import BiologyExpertAgent
+from .chemistry_expert import ChemistryExpertAgent
+from .cs_expert import CSExpertAgent
+from .english_expert import EnglishExpertAgent
+from .literature_expert import LiteratureExpertAgent
+from .math_expert import MathExpertAgent
+from .physics_expert import PhysicsExpertAgent
 
 __all__ = [
-    "BaseAgent",
-    "InfoAgent",
+    "BiologyExpertAgent",
+    "ChemistryExpertAgent",
     "CSExpertAgent",
+    "EnglishExpertAgent",
+    "LiteratureExpertAgent",
     "MathExpertAgent",
     "PhysicsExpertAgent",
-    "SubjectExpertAgent",
-    "BiologyExpertAgent",
-    "EnglishExpertAgent",
-    "ChemistryExpertAgent",
-    "LiteratureExpertAgent",
 ]
+

--- a/config/agents/subject_experts/chemistry_expert.py
+++ b/config/agents/subject_experts/chemistry_expert.py
@@ -1,7 +1,7 @@
 """
 Chemistry Expert Agent
 """
-from agents.base_agent import SubjectExpertAgent
+from ..base_agent import SubjectExpertAgent
 
 class ChemistryExpertAgent(SubjectExpertAgent):
     """Chemistry Expert Agent"""

--- a/config/agents/subject_experts/cs_expert.py
+++ b/config/agents/subject_experts/cs_expert.py
@@ -1,7 +1,7 @@
 """
 Computer Science Expert Agent
 """
-from agents.base_agent import SubjectExpertAgent
+from ..base_agent import SubjectExpertAgent
 
 class CSExpertAgent(SubjectExpertAgent):
     """Computer Science Expert Agent"""

--- a/llm_config.py
+++ b/llm_config.py
@@ -1,0 +1,28 @@
+"""Minimal LLM configuration utilities."""
+
+from typing import Any, Dict
+
+
+class LLMConfig:
+    """Utility helpers to construct LLM configuration dictionaries."""
+
+    default_model: str = "gpt-4o-mini"
+
+    @classmethod
+    def get_config(cls, **overrides: Any) -> Dict[str, Any]:
+        """Return a base configuration for the language model."""
+        config: Dict[str, Any] = {"model": cls.default_model, "temperature": 0}
+        config.update(overrides)
+        return config
+
+    @classmethod
+    def get_expert_config(cls, subject: str, **overrides: Any) -> Dict[str, Any]:
+        """Return a configuration tuned for expert agents."""
+        # For now this simply returns the base config with a lower temperature.
+        base = cls.get_config(temperature=0.2)
+        base.update(overrides)
+        return base
+
+
+__all__ = ["LLMConfig"]
+

--- a/settings.py
+++ b/settings.py
@@ -1,0 +1,27 @@
+"""Application settings for the AutoGen service."""
+
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass
+class Settings:
+    """Basic configuration options.
+
+    The defaults provide sensible values for development and testing
+    environments. They can be extended or overridden as needed.
+    """
+
+    max_rounds: int = 10
+    max_consecutive_auto_reply: int = 3
+    human_input_mode: str = "NEVER"
+    termination_msg: str = "TERMINATE"
+    data_path: Path = Path(__file__).resolve().parent / "data"
+
+
+# Global settings instance
+settings = Settings()
+
+
+__all__ = ["Settings", "settings"]
+


### PR DESCRIPTION
## Summary
- add missing package initializers and fix relative imports for agents
- introduce simple settings and LLM config utilities
- implement a mock FastAPI service to retrieve subject data

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python - <<'PY'
from api.mock_api import list_subjects, get_syllabus
print(list_subjects())
print(get_syllabus('math')['subject'])
PY`

------
https://chatgpt.com/codex/tasks/task_b_68accd15dc7c8332bb18eaaaead252e2