### PR TITLE
Fix configuration imports by adding default settings

### DIFF
--- a/config/agents/info_agent.py
+++ b/config/agents/info_agent.py
@@ -5,7 +5,8 @@ import json
 import os
 from typing import Dict, Any, List, Optional
 from pathlib import Path
-from agents.base_agent import BaseAgent
+
+from .base_agent import BaseAgent
 from config.settings import settings
 
 class InfoAgent(BaseAgent):

--- a/config/agents/subject_experts/__init__.py
+++ b/config/agents/subject_experts/__init__.py
@@ -11,17 +11,17 @@ corresponding module at the project root.
 
 from __future__ import annotations
 
-from .base_agent import BaseAgent, SubjectExpertAgent  # noqa: F401
-from .info_agent import InfoAgent  # noqa: F401
+from ..base_agent import BaseAgent, SubjectExpertAgent  # noqa: F401
+from ..info_agent import InfoAgent  # noqa: F401
 
 # Import subject experts into the package namespace for convenience
-from .subject_experts.cs_expert import CSExpertAgent
-from .subject_experts.math_expert import MathExpertAgent
-from .subject_experts.english_expert import EnglishExpertAgent
-from .subject_experts.biology_expert import BiologyExpertAgent
-from .subject_experts.physics_expert import PhysicsExpertAgent
-from .subject_experts.chemistry_expert import ChemistryExpertAgent
-from .subject_experts.literature_expert import LiteratureExpertAgent 
+from .cs_expert import CSExpertAgent
+from .math_expert import MathExpertAgent
+from .english_expert import EnglishExpertAgent
+from .biology_expert import BiologyExpertAgent
+from .physics_expert import PhysicsExpertAgent
+from .chemistry_expert import ChemistryExpertAgent
+from .literature_expert import LiteratureExpertAgent
 
 __all__ = [
     "BaseAgent",

--- a/config/agents/subject_experts/chemistry_expert.py
+++ b/config/agents/subject_experts/chemistry_expert.py
@@ -1,7 +1,7 @@
 """
 Chemistry Expert Agent
 """
-from agents.base_agent import SubjectExpertAgent
+from ..base_agent import SubjectExpertAgent
 
 class ChemistryExpertAgent(SubjectExpertAgent):
     """Chemistry Expert Agent"""

--- a/config/agents/subject_experts/cs_expert.py
+++ b/config/agents/subject_experts/cs_expert.py
@@ -1,7 +1,7 @@
 """
 Computer Science Expert Agent
 """
-from agents.base_agent import SubjectExpertAgent
+from ..base_agent import SubjectExpertAgent
 
 class CSExpertAgent(SubjectExpertAgent):
     """Computer Science Expert Agent"""

--- a/config/agents/subject_experts/english_expert.py
+++ b/config/agents/subject_experts/english_expert.py
@@ -15,7 +15,7 @@ https://microsoft.github.io/autogen/stable//user-guide/agentchat-user-guide/inde
 
 from __future__ import annotations
 
-from base_agent import SubjectExpertAgent
+from ..base_agent import SubjectExpertAgent
 
 
 class EnglishExpertAgent(SubjectExpertAgent):

--- a/config/agents/subject_experts/literature_expert.py
+++ b/config/agents/subject_experts/literature_expert.py
@@ -15,7 +15,7 @@ https://microsoft.github.io/autogen/stable//user-guide/agentchat-user-guide/inde
 
 from __future__ import annotations
 
-from base_agent import SubjectExpertAgent
+from ..base_agent import SubjectExpertAgent
 
 
 class LiteratureExpertAgent(SubjectExpertAgent):

--- a/config/agents/subject_experts/physics_expert.py
+++ b/config/agents/subject_experts/physics_expert.py
@@ -16,7 +16,7 @@ https://microsoft.github.io/autogen/stable//user-guide/agentchat-user-guide/inde
 
 from __future__ import annotations
 
-from base_agent import SubjectExpertAgent
+from ..base_agent import SubjectExpertAgent
 
 
 class PhysicsExpertAgent(SubjectExpertAgent):

--- a/llm_config.py
+++ b/llm_config.py
@@ -1,0 +1,42 @@
+"""Utility helpers for constructing LLM configuration dictionaries."""
+
+from typing import Any, Dict
+import os
+
+
+class LLMConfig:
+    """Factory for language‑model configuration dictionaries."""
+
+    DEFAULT_MODEL = os.getenv("OPENAI_MODEL", "gpt-4o-mini")
+
+    @staticmethod
+    def get_config(model: str | None = None, temperature: float = 0.7, **overrides: Any) -> Dict[str, Any]:
+        """Return a basic configuration for an LLM call.
+
+        Parameters
+        ----------
+        model:
+            Optional model name to use.  If omitted, ``DEFAULT_MODEL`` is used.
+        temperature:
+            Sampling temperature for the model.
+        overrides:
+            Additional keyword arguments are merged into the returned dict.
+        """
+        config: Dict[str, Any] = {
+            "model": model or LLMConfig.DEFAULT_MODEL,
+            "temperature": temperature,
+        }
+        config.update(overrides)
+        return config
+
+    @staticmethod
+    def get_expert_config(subject: str, **overrides: Any) -> Dict[str, Any]:
+        """Return configuration tuned for a particular subject expert.
+
+        Currently this simply proxies to :meth:`get_config`, but the method
+        exists to allow easy per‑subject customisation in the future.
+        """
+        return LLMConfig.get_config(**overrides)
+
+
+__all__ = ["LLMConfig"]

--- a/settings.py
+++ b/settings.py
@@ -1,0 +1,29 @@
+"""Application configuration settings for the AutoGen Education Service."""
+
+from dataclasses import dataclass, field
+from pathlib import Path
+import os
+
+
+@dataclass
+class Settings:
+    """Runtime configuration loaded from environment variables.
+
+    The class provides sensible defaults so the package can operate in
+    a development environment without additional configuration."""
+
+    openai_api_key: str = field(default_factory=lambda: os.getenv("OPENAI_API_KEY", ""))
+    azure_openai_api_key: str = field(default_factory=lambda: os.getenv("AZURE_OPENAI_API_KEY", ""))
+    max_rounds: int = field(default_factory=lambda: int(os.getenv("MAX_ROUNDS", "10")))
+    termination_msg: str = field(default_factory=lambda: os.getenv("TERMINATION_MSG", "TERMINATE"))
+    max_consecutive_auto_reply: int = field(
+        default_factory=lambda: int(os.getenv("MAX_CONSECUTIVE_AUTO_REPLY", "3"))
+    )
+    human_input_mode: str = field(default_factory=lambda: os.getenv("HUMAN_INPUT_MODE", "NEVER"))
+    data_path: Path = field(default_factory=lambda: Path(os.getenv("DATA_PATH", "data")))
+
+
+# Instantiate a single settings object that can be imported elsewhere
+settings = Settings()
+
+__all__ = ["Settings", "settings"]


### PR DESCRIPTION
## Summary
- add default `Settings` dataclass and `settings` instance
- implement `LLMConfig` helper with `get_config`/`get_expert_config`
- fix agent modules to use package-relative imports

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68accccafc1c833290e4f4b60713bc74