### PR TITLE
Centralize expert prompts and fix group chat selector

### DIFF
--- a/chat/selector_group_chat.py
+++ b/chat/selector_group_chat.py
@@ -1,7 +1,7 @@
 """
 Selector Group Chat implementation for AutoGen
 """
-from typing import List, Dict, Any, Optional, Callable
+from typing import List, Dict, Any, Optional, Callable, Union
 from autogen import GroupChat, GroupChatManager, Agent
 from config.settings import settings
 from config.llm_config import LLMConfig
@@ -18,7 +18,7 @@ class SelectorGroupChat:
     def __init__(
         self,
         agents: List[Agent],
-        max_rounds: int = None,
+        max_rounds: Optional[int] = None,
         admin_name: str = "Admin",
         selection_method: str = "auto"  # auto, manual, or custom
     ):
@@ -53,14 +53,13 @@ class SelectorGroupChat:
             system_message=GROUP_CHAT_MANAGER_PROMPT,
         )
     
-    def _get_selection_method(self) -> str:
+    def _get_selection_method(self) -> Union[str, Callable]:
         """Get the speaker selection method"""
         if self.selection_method == "manual":
             return "manual"
-        elif self.selection_method == "custom" and hasattr(self, "custom_selector"):
+        if self.selection_method == "custom" and hasattr(self, "custom_selector"):
             return self.custom_selector
-        else:
-            return "auto"  # Let AutoGen handle selection automatically
+        return "auto"  # Let AutoGen handle selection automatically
     
     def set_custom_selector(self, selector_function: Callable) -> None:
         """Set a custom selector function"""
@@ -99,7 +98,7 @@ class SelectorGroupChat:
             
             # Select agent with highest score
             if agent_scores:
-                selected_name = max(agent_scores, key=agent_scores.get)
+                selected_name = max(agent_scores, key=lambda k: agent_scores[k])
                 for agent in self.agents:
                     if agent.name == selected_name:
                         return agent

--- a/config/agents/subject_experts/chemistry_expert.py
+++ b/config/agents/subject_experts/chemistry_expert.py
@@ -2,6 +2,7 @@
 Chemistry Expert Agent
 """
 from ..base_agent import SubjectExpertAgent
+from config.expert_prompts import EXPERT_PROMPTS
 
 class ChemistryExpertAgent(SubjectExpertAgent):
     """Chemistry Expert Agent"""
@@ -21,30 +22,7 @@ class ChemistryExpertAgent(SubjectExpertAgent):
                 "Nuclear Chemistry",
                 "Polymer Chemistry"
             ],
-            additional_instructions="""
-Special capabilities for Chemistry:
-- Balance chemical equations and redox reactions
-- Predict reaction products and mechanisms
-- Calculate stoichiometry and yields
-- Explain molecular structure and bonding
-- Analyze spectroscopic data (NMR, IR, MS)
-- Design synthetic pathways
-- Explain laboratory techniques and safety
-- Relate chemistry to biological and environmental systems
-
-Problem-solving approach:
-1. Identify the type of chemical problem
-2. Write balanced equations when applicable
-3. Draw molecular structures clearly
-4. Apply relevant chemical principles
-5. Show calculations with proper significant figures
-6. Include units and chemical formulas
-7. Consider reaction conditions
-8. Discuss practical implications
-
-Use IUPAC nomenclature and standard chemical notation.
-Emphasize safety considerations when discussing experiments.
-""",
+            additional_instructions=EXPERT_PROMPTS["Chemistry_Expert"],
             **kwargs
         )
     

--- a/config/agents/subject_experts/cs_expert.py
+++ b/config/agents/subject_experts/cs_expert.py
@@ -2,6 +2,7 @@
 Computer Science Expert Agent
 """
 from ..base_agent import SubjectExpertAgent
+from config.expert_prompts import EXPERT_PROMPTS
 
 class CSExpertAgent(SubjectExpertAgent):
     """Computer Science Expert Agent"""
@@ -21,35 +22,7 @@ class CSExpertAgent(SubjectExpertAgent):
                 "Artificial Intelligence and Machine Learning",
                 "Web Development (Frontend, Backend, APIs)"
             ],
-            additional_instructions="""
-Special capabilities for Computer Science:
-- Write and debug code in multiple languages
-- Analyze algorithm complexity (time and space)
-- Design efficient data structures
-- Explain system architecture and design patterns
-- Optimize code performance
-- Debug and fix errors
-- Design databases and write queries
-- Explain networking and security concepts
-
-Problem-solving approach:
-1. Understand requirements clearly
-2. Design solution architecture
-3. Choose appropriate data structures
-4. Implement with clean, readable code
-5. Include comments and documentation
-6. Analyze complexity
-7. Test with edge cases
-8. Optimize if needed
-
-Code standards:
-- Use meaningful variable names
-- Follow language-specific conventions
-- Include error handling
-- Write modular, reusable code
-- Add comprehensive comments
-- Consider security implications
-""",
+            additional_instructions=EXPERT_PROMPTS["CS_Expert"],
             **kwargs
         )
     

--- a/config/agents/subject_experts/english_expert.py
+++ b/config/agents/subject_experts/english_expert.py
@@ -16,6 +16,7 @@ https://microsoft.github.io/autogen/stable//user-guide/agentchat-user-guide/inde
 from __future__ import annotations
 
 from ..base_agent import SubjectExpertAgent
+from config.expert_prompts import EXPERT_PROMPTS
 
 
 class EnglishExpertAgent(SubjectExpertAgent):
@@ -34,28 +35,7 @@ class EnglishExpertAgent(SubjectExpertAgent):
                 "Speaking and Listening",
                 "Test Preparation (IELTS, TOEFL, TOEIC)",
             ],
-            additional_instructions="""
-Special capabilities for English Language:
-- Explain grammar rules with examples and exceptions
-- Expand vocabulary through definitions, synonyms and usage
-- Provide pronunciation guidance using phonetic transcriptions
-- Evaluate and correct writing for clarity and coherence
-- Offer strategies for effective listening and speaking
-- Tailor lessons to different proficiency levels
-- Prepare learners for standardized tests (IELTS, TOEFL, etc.)
-
-Teaching approach:
-1. Assess the learner's current level and goals
-2. Introduce concepts gradually with clear explanations
-3. Provide plenty of examples and practice sentences
-4. Use real‑life contexts to illustrate language use
-5. Encourage active use of language through exercises
-6. Correct errors gently and explain the reasoning
-7. Summarize key points and provide follow‑up resources
-
-Use clear and simple language when appropriate, and define linguistic
-terms.  Adapt explanations to the learner's background and needs.
-""",
+            additional_instructions=EXPERT_PROMPTS["English_Expert"],
             **kwargs,
         )
 

--- a/config/agents/subject_experts/literature_expert.py
+++ b/config/agents/subject_experts/literature_expert.py
@@ -16,6 +16,7 @@ https://microsoft.github.io/autogen/stable//user-guide/agentchat-user-guide/inde
 from __future__ import annotations
 
 from ..base_agent import SubjectExpertAgent
+from config.expert_prompts import EXPERT_PROMPTS
 
 
 class LiteratureExpertAgent(SubjectExpertAgent):
@@ -34,25 +35,7 @@ class LiteratureExpertAgent(SubjectExpertAgent):
                 "Rhetoric and Composition",
                 "Comparative Literature",
             ],
-            additional_instructions="""
-Special capabilities for Literature:
-- Analyze texts for themes, motifs and deeper meaning
-- Provide contextual information about authors and historical periods
-- Compare and contrast works across genres and cultures
-- Offer writing guidance on essays, creative writing and research papers
-- Recommend reading lists based on interests or curricula
-- Explain literary devices and how they function within a text
-
-Teaching approach:
-1. Encourage close reading and textual evidence
-2. Discuss multiple interpretations and perspectives
-3. Connect literature to its historical and cultural context
-4. Foster critical thinking and personal engagement
-5. Provide constructive feedback on writing
-6. Highlight intertextual connections and influences
-
-Use appropriate literary terminology and cite sources when relevant.
-""",
+            additional_instructions=EXPERT_PROMPTS["Literature_Expert"],
             **kwargs,
         )
 

--- a/config/agents/subject_experts/physics_expert.py
+++ b/config/agents/subject_experts/physics_expert.py
@@ -17,6 +17,7 @@ https://microsoft.github.io/autogen/stable//user-guide/agentchat-user-guide/inde
 from __future__ import annotations
 
 from ..base_agent import SubjectExpertAgent
+from config.expert_prompts import EXPERT_PROMPTS
 
 
 class PhysicsExpertAgent(SubjectExpertAgent):
@@ -36,26 +37,7 @@ class PhysicsExpertAgent(SubjectExpertAgent):
                 "Fluid Dynamics",
                 "Astrophysics and Cosmology",
             ],
-            additional_instructions="""
-Special capabilities for Physics:
-- Solve numerical and conceptual problems using fundamental laws
-- Derive formulas from basic principles
-- Interpret experimental data and graphs
-- Explain physical phenomena with clear analogies
-- Perform unit analysis and dimensional checks
-- Apply appropriate approximations and simplifying assumptions
-
-Teaching approach:
-1. State known quantities and governing laws
-2. Draw diagrams where necessary
-3. Use free‑body diagrams and circuit diagrams to illustrate problems
-4. Show derivations step by step with explanations
-5. Discuss limiting cases and special situations
-6. Emphasize conceptual understanding before calculations
-7. Connect physical concepts to real‑world examples and experiments
-
-Use SI units unless otherwise specified and define all symbols used.
-""",
+            additional_instructions=EXPERT_PROMPTS["Physics_Expert"],
             **kwargs,
         )
 

--- a/config/expert_prompts.py
+++ b/config/expert_prompts.py
@@ -1,0 +1,120 @@
+"""Prompt configuration for subject expert agents."""
+
+EXPERT_PROMPTS = {
+    "CS_Expert": """
+Special capabilities for Computer Science:
+- Write and debug code in multiple languages
+- Analyze algorithm complexity (time and space)
+- Design efficient data structures
+- Explain system architecture and design patterns
+- Optimize code performance
+- Debug and fix errors
+- Design databases and write queries
+- Explain networking and security concepts
+
+Problem-solving approach:
+1. Understand requirements clearly
+2. Design solution architecture
+3. Choose appropriate data structures
+4. Implement with clean, readable code
+5. Include comments and documentation
+6. Analyze complexity
+7. Test with edge cases
+8. Optimize if needed
+
+Code standards:
+- Use meaningful variable names
+- Follow language-specific conventions
+- Include error handling
+- Write modular, reusable code
+- Add comprehensive comments
+- Consider security implications
+""",
+    "Physics_Expert": """
+Special capabilities for Physics:
+- Solve numerical and conceptual problems using fundamental laws
+- Derive formulas from basic principles
+- Interpret experimental data and graphs
+- Explain physical phenomena with clear analogies
+- Perform unit analysis and dimensional checks
+- Apply appropriate approximations and simplifying assumptions
+
+Teaching approach:
+1. State known quantities and governing laws
+2. Draw diagrams where necessary
+3. Use free-body diagrams and circuit diagrams to illustrate problems
+4. Show derivations step by step with explanations
+5. Discuss limiting cases and special situations
+6. Emphasize conceptual understanding before calculations
+7. Connect physical concepts to real-world examples and experiments
+
+Use SI units unless otherwise specified and define all symbols used.
+""",
+    "Chemistry_Expert": """
+Special capabilities for Chemistry:
+- Balance chemical equations and redox reactions
+- Predict reaction products and mechanisms
+- Calculate stoichiometry and yields
+- Explain molecular structure and bonding
+- Analyze spectroscopic data (NMR, IR, MS)
+- Design synthetic pathways
+- Explain laboratory techniques and safety
+- Relate chemistry to biological and environmental systems
+
+Problem-solving approach:
+1. Identify the type of chemical problem
+2. Write balanced equations when applicable
+3. Draw molecular structures clearly
+4. Apply relevant chemical principles
+5. Show calculations with proper significant figures
+6. Include units and chemical formulas
+7. Consider reaction conditions
+8. Discuss practical implications
+
+Use IUPAC nomenclature and standard chemical notation.
+Emphasize safety considerations when discussing experiments.
+""",
+    "English_Expert": """
+Special capabilities for English Language:
+- Explain grammar rules with examples and exceptions
+- Expand vocabulary through definitions, synonyms and usage
+- Provide pronunciation guidance using phonetic transcriptions
+- Evaluate and correct writing for clarity and coherence
+- Offer strategies for effective listening and speaking
+- Tailor lessons to different proficiency levels
+- Prepare learners for standardized tests (IELTS, TOEFL, etc.)
+
+Teaching approach:
+1. Assess the learner's current level and goals
+2. Introduce concepts gradually with clear explanations
+3. Provide plenty of examples and practice sentences
+4. Use real-life contexts to illustrate language use
+5. Encourage active use of language through exercises
+6. Correct errors gently and explain the reasoning
+7. Summarize key points and provide follow-up resources
+
+Use clear and simple language when appropriate, and define linguistic
+terms.  Adapt explanations to the learner's background and needs.
+""",
+    "Literature_Expert": """
+Special capabilities for Literature:
+- Analyze texts for themes, motifs and deeper meaning
+- Provide contextual information about authors and historical periods
+- Compare and contrast works across genres and cultures
+- Offer writing guidance on essays, creative writing and research papers
+- Recommend reading lists based on interests or curricula
+- Explain literary devices and how they function within a text
+
+Teaching approach:
+1. Encourage close reading and textual evidence
+2. Discuss multiple interpretations and perspectives
+3. Connect literature to its historical and cultural context
+4. Foster critical thinking and personal engagement
+5. Provide constructive feedback on writing
+6. Highlight intertextual connections and influences
+
+Use appropriate literary terminology and cite sources when relevant.
+""",
+}
+
+__all__ = ["EXPERT_PROMPTS"]

--- a/main.py
+++ b/main.py
@@ -1,0 +1,8 @@
+"""Entry point for running the FastAPI application."""
+
+from api.mock_api import app
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,8 @@
 pymongo
 mgclient
+fastapi
+pandas
+autogen
+rich
+colorama
+uvicorn


### PR DESCRIPTION
## Summary
- Centralize subject expert additional instructions in a new `EXPERT_PROMPTS` config
- Fix selector type hints and max usage in group chat helper
- Provide a simple `main.py` entrypoint and expand requirements list

## Testing
- `python -m py_compile config/agents/subject_experts/english_expert.py config/agents/subject_experts/literature_expert.py config/agents/subject_experts/chemistry_expert.py config/agents/subject_experts/physics_expert.py config/agents/subject_experts/cs_expert.py chat/selector_group_chat.py config/expert_prompts.py main.py`
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement mgclient)*

------
https://chatgpt.com/codex/tasks/task_b_68acd4f5fb64833294a2822e6d93a3ba