### PR TITLE
Refine typing for agent selection and expert replies

### DIFF
--- a/chat/selector_group_chat.py
+++ b/chat/selector_group_chat.py
@@ -1,7 +1,14 @@
-"""
-Selector Group Chat implementation for AutoGen
-"""
-from typing import List, Dict, Any, Optional, Callable, Union
+"""Selector Group Chat implementation for AutoGen."""
+
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Union,
+    Literal,
+)
 from autogen import GroupChat, GroupChatManager, Agent
 from config.settings import settings
 from config.llm_config import LLMConfig
@@ -53,8 +60,13 @@ class SelectorGroupChat:
             system_message=GROUP_CHAT_MANAGER_PROMPT,
         )
     
-    def _get_selection_method(self) -> Union[str, Callable]:
-        """Get the speaker selection method"""
+    def _get_selection_method(
+        self,
+    ) -> Union[
+        Callable[[Agent, GroupChat], Agent],
+        Literal["auto", "manual", "random", "round_robin"],
+    ]:
+        """Get the speaker selection method."""
         if self.selection_method == "manual":
             return "manual"
         if self.selection_method == "custom" and hasattr(self, "custom_selector"):

--- a/config/agents/base_agent.py
+++ b/config/agents/base_agent.py
@@ -3,7 +3,7 @@ Base Agent class for all AutoGen agents
 """
 from config.settings import settings
 from config.llm_config import LLMConfig
-from typing import Dict, Any, Optional, List
+from typing import Any, Dict, List, Optional, Literal, cast
 from autogen import AssistantAgent, UserProxyAgent
 from config.prompts import SUBJECT_EXPERT_PROMPT_TEMPLATE
 
@@ -16,13 +16,18 @@ class BaseAgent:
         system_message: str,
         llm_config: Optional[Dict[str, Any]] = None,
         max_consecutive_auto_reply: Optional[int] = None,
-        human_input_mode: Optional[str] = None
+        human_input_mode: Optional[Literal["ALWAYS", "NEVER", "TERMINATE"]] = None,
     ):
         self.name = name
         self.system_message = system_message
         self.llm_config = llm_config or LLMConfig.get_config()
-        self.max_consecutive_auto_reply = max_consecutive_auto_reply or settings.max_consecutive_auto_reply
-        self.human_input_mode = human_input_mode or settings.human_input_mode
+        self.max_consecutive_auto_reply = (
+            max_consecutive_auto_reply or settings.max_consecutive_auto_reply
+        )
+        self.human_input_mode = human_input_mode or cast(
+            Literal["ALWAYS", "NEVER", "TERMINATE"],
+            settings.human_input_mode,
+        )
         self.agent = self._create_agent()
     
     def _create_agent(self) -> AssistantAgent:

--- a/config/agents/subject_experts/chemistry_expert.py
+++ b/config/agents/subject_experts/chemistry_expert.py
@@ -1,6 +1,7 @@
-"""
-Chemistry Expert Agent
-"""
+"""Chemistry Expert Agent."""
+
+from typing import cast
+
 from ..base_agent import SubjectExpertAgent
 from config.expert_prompts import EXPERT_PROMPTS
 from .prompts import (
@@ -33,7 +34,12 @@ class ChemistryExpertAgent(SubjectExpertAgent):
     def balance_equation(self, equation: str) -> str:
         """Balance a chemical equation"""
         prompt = CHEM_BALANCE_EQUATION_PROMPT.format(equation=equation)
-        return self.agent.generate_reply(messages=[{"content": prompt, "role": "user"}])
+        return cast(
+            str,
+            self.agent.generate_reply(
+                messages=[{"content": prompt, "role": "user"}]
+            ),
+        )
     
     def predict_reaction(self, reactants: str, conditions: str = "") -> str:
         """Predict reaction products and mechanism"""
@@ -41,4 +47,9 @@ class ChemistryExpertAgent(SubjectExpertAgent):
             reactants=reactants,
             conditions=conditions if conditions else "Standard conditions",
         )
-        return self.agent.generate_reply(messages=[{"content": prompt, "role": "user"}])
+        return cast(
+            str,
+            self.agent.generate_reply(
+                messages=[{"content": prompt, "role": "user"}]
+            ),
+        )

--- a/config/agents/subject_experts/cs_expert.py
+++ b/config/agents/subject_experts/cs_expert.py
@@ -1,4 +1,6 @@
-"""Computer Science Expert Agent"""
+"""Computer Science Expert Agent."""
+
+from typing import cast
 
 from ..base_agent import SubjectExpertAgent
 from config.expert_prompts import EXPERT_PROMPTS
@@ -8,9 +10,10 @@ from .prompts import (
     CS_EXPLAIN_ALGORITHM_PROMPT,
 )
 
+
 class CSExpertAgent(SubjectExpertAgent):
-    """Computer Science Expert Agent"""
-    
+    """Computer Science Expert Agent."""
+
     def __init__(self, **kwargs):
         super().__init__(
             name="CS_Expert",
@@ -24,25 +27,41 @@ class CSExpertAgent(SubjectExpertAgent):
                 "Operating Systems (Processes, Memory, File Systems)",
                 "Computer Networks (TCP/IP, HTTP, Security)",
                 "Artificial Intelligence and Machine Learning",
-                "Web Development (Frontend, Backend, APIs)"
+                "Web Development (Frontend, Backend, APIs)",
             ],
             additional_instructions=EXPERT_PROMPTS["CS_Expert"],
-            **kwargs
+            **kwargs,
         )
-    
+
     def write_code(self, problem: str, language: str = "Python") -> str:
-        """Write code to solve a problem"""
+        """Write code to solve a problem."""
         prompt = CS_WRITE_CODE_PROMPT.format(language=language, problem=problem)
-        return self.agent.generate_reply(messages=[{"content": prompt, "role": "user"}])
-    
+        return cast(
+            str,
+            self.agent.generate_reply(
+                messages=[{"content": prompt, "role": "user"}]
+            ),
+        )
+
     def debug_code(self, code: str, error: str = "") -> str:
-        """Debug code and fix errors"""
+        """Debug code and fix errors."""
         prompt = CS_DEBUG_CODE_PROMPT.format(
             code=code, error=error if error else "Unknown error"
         )
-        return self.agent.generate_reply(messages=[{"content": prompt, "role": "user"}])
-    
+        return cast(
+            str,
+            self.agent.generate_reply(
+                messages=[{"content": prompt, "role": "user"}]
+            ),
+        )
+
     def explain_algorithm(self, algorithm: str) -> str:
-        """Explain an algorithm in detail"""
+        """Explain an algorithm in detail."""
         prompt = CS_EXPLAIN_ALGORITHM_PROMPT.format(algorithm=algorithm)
-        return self.agent.generate_reply(messages=[{"content": prompt, "role": "user"}])
+        return cast(
+            str,
+            self.agent.generate_reply(
+                messages=[{"content": prompt, "role": "user"}]
+            ),
+        )
+

--- a/config/agents/subject_experts/english_expert.py
+++ b/config/agents/subject_experts/english_expert.py
@@ -15,6 +15,8 @@ https://microsoft.github.io/autogen/stable//user-guide/agentchat-user-guide/inde
 
 from __future__ import annotations
 
+from typing import cast
+
 from ..base_agent import SubjectExpertAgent
 from config.expert_prompts import EXPERT_PROMPTS
 from .prompts import (
@@ -46,9 +48,19 @@ class EnglishExpertAgent(SubjectExpertAgent):
     def correct_grammar(self, sentence: str) -> str:
         """Correct the grammar of a sentence and explain the corrections"""
         prompt = ENGLISH_CORRECT_GRAMMAR_PROMPT.format(sentence=sentence)
-        return self.agent.generate_reply(messages=[{"content": prompt, "role": "user"}])
+        return cast(
+            str,
+            self.agent.generate_reply(
+                messages=[{"content": prompt, "role": "user"}]
+            ),
+        )
 
     def build_vocabulary(self, word: str) -> str:
         """Explain a word's meaning, usage and related terms"""
         prompt = ENGLISH_BUILD_VOCABULARY_PROMPT.format(word=word)
-        return self.agent.generate_reply(messages=[{"content": prompt, "role": "user"}])
+        return cast(
+            str,
+            self.agent.generate_reply(
+                messages=[{"content": prompt, "role": "user"}]
+            ),
+        )

--- a/config/agents/subject_experts/literature_expert.py
+++ b/config/agents/subject_experts/literature_expert.py
@@ -15,6 +15,8 @@ https://microsoft.github.io/autogen/stable//user-guide/agentchat-user-guide/inde
 
 from __future__ import annotations
 
+from typing import cast
+
 from ..base_agent import SubjectExpertAgent
 from config.expert_prompts import EXPERT_PROMPTS
 from .prompts import (
@@ -49,9 +51,19 @@ class LiteratureExpertAgent(SubjectExpertAgent):
         prompt = LIT_ANALYZE_TEXT_PROMPT.format(
             text=text, question_part=question_part
         )
-        return self.agent.generate_reply(messages=[{"content": prompt, "role": "user"}])
+        return cast(
+            str,
+            self.agent.generate_reply(
+                messages=[{"content": prompt, "role": "user"}]
+            ),
+        )
 
     def give_writing_advice(self, assignment: str) -> str:
         """Provide advice for a writing assignment"""
         prompt = LIT_GIVE_WRITING_ADVICE_PROMPT.format(assignment=assignment)
-        return self.agent.generate_reply(messages=[{"content": prompt, "role": "user"}])
+        return cast(
+            str,
+            self.agent.generate_reply(
+                messages=[{"content": prompt, "role": "user"}]
+            ),
+        )

--- a/config/agents/subject_experts/physics_expert.py
+++ b/config/agents/subject_experts/physics_expert.py
@@ -16,6 +16,8 @@ https://microsoft.github.io/autogen/stable//user-guide/agentchat-user-guide/inde
 
 from __future__ import annotations
 
+from typing import cast
+
 from ..base_agent import SubjectExpertAgent
 from config.expert_prompts import EXPERT_PROMPTS
 from .prompts import (
@@ -48,9 +50,19 @@ class PhysicsExpertAgent(SubjectExpertAgent):
     def solve_problem(self, problem: str) -> str:
         """Solve a physics problem with full reasoning"""
         prompt = PHYSICS_SOLVE_PROBLEM_PROMPT.format(problem=problem)
-        return self.agent.generate_reply(messages=[{"content": prompt, "role": "user"}])
+        return cast(
+            str,
+            self.agent.generate_reply(
+                messages=[{"content": prompt, "role": "user"}]
+            ),
+        )
 
     def explain_concept(self, concept: str) -> str:
         """Explain a physics concept in detail"""
         prompt = PHYSICS_EXPLAIN_CONCEPT_PROMPT.format(concept=concept)
-        return self.agent.generate_reply(messages=[{"content": prompt, "role": "user"}])
+        return cast(
+            str,
+            self.agent.generate_reply(
+                messages=[{"content": prompt, "role": "user"}]
+            ),
+        )


### PR DESCRIPTION
## Summary
- Tighten typing for group chat speaker selection using Literal values and callable signatures
- Restrict `human_input_mode` to allowed literals and cast settings values
- Ensure subject expert helper methods return strings by casting `generate_reply` outputs

## Testing
- `python -m py_compile chat/selector_group_chat.py config/agents/base_agent.py config/agents/subject_experts/chemistry_expert.py config/agents/subject_experts/cs_expert.py config/agents/subject_experts/english_expert.py config/agents/subject_experts/physics_expert.py config/agents/subject_experts/literature_expert.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68acdb71f56c8332bfe4a6f324f55691