### PR TITLE
Implement math and biology experts and fix typing

### DIFF
--- a/chat/selector_group_chat.py
+++ b/chat/selector_group_chat.py
@@ -9,7 +9,7 @@ from typing import (
     Union,
     Literal,
 )
-from autogen import GroupChat, GroupChatManager, Agent
+from autogen import GroupChat, GroupChatManager, ConversableAgent
 from config.settings import settings
 from config.llm_config import LLMConfig
 from config.prompts import (
@@ -24,7 +24,7 @@ class SelectorGroupChat:
     
     def __init__(
         self,
-        agents: List[Agent],
+        agents: List[ConversableAgent],
         max_rounds: Optional[int] = None,
         admin_name: str = "Admin",
         selection_method: str = "auto"  # auto, manual, or custom
@@ -63,7 +63,7 @@ class SelectorGroupChat:
     def _get_selection_method(
         self,
     ) -> Union[
-        Callable[[Agent, GroupChat], Agent],
+        Callable[[ConversableAgent, GroupChat], ConversableAgent],
         Literal["auto", "manual", "random", "round_robin"],
     ]:
         """Get the speaker selection method."""
@@ -79,9 +79,9 @@ class SelectorGroupChat:
         self.selection_method = "custom"
         self.group_chat.speaker_selection_method = selector_function
     
-    def create_subject_selector(self) -> Callable:
+    def create_subject_selector(self) -> Callable[[ConversableAgent, GroupChat], ConversableAgent]:
         """Create a subject-based selector function"""
-        def select_speaker(last_speaker: Agent, groupchat: GroupChat) -> Agent:
+        def select_speaker(last_speaker: ConversableAgent, groupchat: GroupChat) -> ConversableAgent:
             """Custom speaker selection based on message content"""
             messages = groupchat.messages
             if not messages:
@@ -121,7 +121,7 @@ class SelectorGroupChat:
         
         return select_speaker
     
-    def start_chat(self, initial_message: str, sender: Optional[Agent] = None) -> None:
+    def start_chat(self, initial_message: str, sender: Optional[ConversableAgent] = None) -> None:
         """Start the group chat"""
         if sender is None:
             # Create a user proxy to send the initial message
@@ -140,7 +140,7 @@ class SelectorGroupChat:
             clear_history=True
         )
     
-    def add_agent(self, agent: Agent) -> None:
+    def add_agent(self, agent: ConversableAgent) -> None:
         """Add a new agent to the group chat"""
         self.agents.append(agent)
         self.group_chat.agents = self.agents
@@ -162,7 +162,7 @@ class SelectorGroupChat:
         """Clear the chat history"""
         self.group_chat.messages = []
     
-    def get_agent_by_name(self, name: str) -> Optional[Agent]:
+    def get_agent_by_name(self, name: str) -> Optional[ConversableAgent]:
         """Get an agent by name"""
         for agent in self.agents:
             if agent.name == name:

--- a/config/agents/base_agent.py
+++ b/config/agents/base_agent.py
@@ -4,19 +4,22 @@ Base Agent class for all AutoGen agents
 from config.settings import settings
 from config.llm_config import LLMConfig
 from typing import Any, Dict, List, Optional, Literal, cast
-from autogen import AssistantAgent, UserProxyAgent
+from autogen import AssistantAgent
 from config.prompts import SUBJECT_EXPERT_PROMPT_TEMPLATE
+
+HumanInputMode = Literal["ALWAYS", "NEVER", "TERMINATE"]
+
 
 class BaseAgent:
     """Base class for all agents in the system"""
-    
+
     def __init__(
         self,
         name: str,
         system_message: str,
         llm_config: Optional[Dict[str, Any]] = None,
         max_consecutive_auto_reply: Optional[int] = None,
-        human_input_mode: Optional[Literal["ALWAYS", "NEVER", "TERMINATE"]] = None,
+        human_input_mode: Optional[HumanInputMode] = None,
     ):
         self.name = name
         self.system_message = system_message
@@ -24,9 +27,12 @@ class BaseAgent:
         self.max_consecutive_auto_reply = (
             max_consecutive_auto_reply or settings.max_consecutive_auto_reply
         )
-        self.human_input_mode = human_input_mode or cast(
-            Literal["ALWAYS", "NEVER", "TERMINATE"],
+        default_human_input_mode: HumanInputMode = cast(
+            HumanInputMode,
             settings.human_input_mode,
+        )
+        self.human_input_mode: HumanInputMode = (
+            human_input_mode or default_human_input_mode
         )
         self.agent = self._create_agent()
     

--- a/config/agents/subject_experts/biology_expert.py
+++ b/config/agents/subject_experts/biology_expert.py
@@ -1,18 +1,43 @@
-"""
-Alias module for the Biology expert agent.
-
-This file exists to provide a more conventional module name for the
-``BiologyExpertAgent`` class, which is defined in
-``bology_expert.py`` (note the historical misspelling).  Importing
-``BiologyExpertAgent`` from ``biology_expert`` simply re‑exports the
-class from the original module.  This alias helps maintain backward
-compatibility while allowing users to import from a correctly spelled
-module name.
-"""
+"""Biology expert agent implementation."""
 
 from __future__ import annotations
 
-# Re-export the BiologyExpertAgent from the original module
-from biology_expert import BiologyExpertAgent  # noqa: F401
+from typing import cast
+
+from ..base_agent import SubjectExpertAgent
+from config.expert_prompts import EXPERT_PROMPTS
+from .prompts import BIOLOGY_EXPLAIN_CONCEPT_PROMPT
+
+
+class BiologyExpertAgent(SubjectExpertAgent):
+    """Biology Expert Agent."""
+
+    def __init__(self, **kwargs):
+        super().__init__(
+            name="Biology_Expert",
+            subject="Biology",
+            expertise_areas=[
+                "Cell Biology",
+                "Genetics",
+                "Evolution",
+                "Ecology",
+                "Physiology",
+                "Biochemistry",
+            ],
+            additional_instructions=EXPERT_PROMPTS["Biology_Expert"],
+            **kwargs,
+        )
+
+    def explain_concept(self, concept: str) -> str:
+        """Explain a biology concept in detail."""
+        prompt = BIOLOGY_EXPLAIN_CONCEPT_PROMPT.format(concept=concept)
+        return cast(
+            str,
+            self.agent.generate_reply(
+                messages=[{"content": prompt, "role": "user"}]
+            ),
+        )
+
 
 __all__ = ["BiologyExpertAgent"]
+

--- a/config/agents/subject_experts/math_expert.py
+++ b/config/agents/subject_experts/math_expert.py
@@ -1,12 +1,43 @@
-"""
-Wrapper for the mathematics expert agent.
-
-This module forwards all exports from the root :mod:`math_expert` module
-to maintain the import path ``agents.subject_experts.math_expert``.
-"""
+"""Mathematics expert agent implementation."""
 
 from __future__ import annotations
 
-from math_expert import MathExpertAgent  # noqa: F401
+from typing import cast
+
+from ..base_agent import SubjectExpertAgent
+from config.expert_prompts import EXPERT_PROMPTS
+from .prompts import MATH_SOLVE_PROBLEM_PROMPT
+
+
+class MathExpertAgent(SubjectExpertAgent):
+    """Mathematics Expert Agent."""
+
+    def __init__(self, **kwargs):
+        super().__init__(
+            name="Math_Expert",
+            subject="Mathematics",
+            expertise_areas=[
+                "Algebra",
+                "Geometry",
+                "Calculus",
+                "Statistics",
+                "Number Theory",
+                "Discrete Mathematics",
+            ],
+            additional_instructions=EXPERT_PROMPTS["Math_Expert"],
+            **kwargs,
+        )
+
+    def solve_problem(self, problem: str) -> str:
+        """Solve a mathematics problem with step-by-step reasoning."""
+        prompt = MATH_SOLVE_PROBLEM_PROMPT.format(problem=problem)
+        return cast(
+            str,
+            self.agent.generate_reply(
+                messages=[{"content": prompt, "role": "user"}]
+            ),
+        )
+
 
 __all__ = ["MathExpertAgent"]
+

--- a/config/agents/subject_experts/prompts.py
+++ b/config/agents/subject_experts/prompts.py
@@ -41,6 +41,17 @@ Include:
 7. Advantages and limitations
 """
 
+MATH_SOLVE_PROBLEM_PROMPT = """
+Solve the following math problem:
+{problem}
+
+Provide:
+1. Restatement of the problem
+2. Step-by-step solution with reasoning
+3. Final answer
+4. Verification of the result
+"""
+
 PHYSICS_SOLVE_PROBLEM_PROMPT = """
 Solve the following physics problem:
 {problem}
@@ -87,6 +98,17 @@ Include:
 2. Reaction mechanism (if applicable)
 3. Reasoning for the prediction
 4. Possible side products
+"""
+
+BIOLOGY_EXPLAIN_CONCEPT_PROMPT = """
+Explain the following biology concept:
+{concept}
+
+Include:
+1. Definition
+2. Key processes or structures involved
+3. Real-world examples or applications
+4. Common misconceptions
 """
 
 ENGLISH_CORRECT_GRAMMAR_PROMPT = """
@@ -141,10 +163,12 @@ __all__ = [
     "CS_WRITE_CODE_PROMPT",
     "CS_DEBUG_CODE_PROMPT",
     "CS_EXPLAIN_ALGORITHM_PROMPT",
+    "MATH_SOLVE_PROBLEM_PROMPT",
     "PHYSICS_SOLVE_PROBLEM_PROMPT",
     "PHYSICS_EXPLAIN_CONCEPT_PROMPT",
     "CHEM_BALANCE_EQUATION_PROMPT",
     "CHEM_PREDICT_REACTION_PROMPT",
+    "BIOLOGY_EXPLAIN_CONCEPT_PROMPT",
     "ENGLISH_CORRECT_GRAMMAR_PROMPT",
     "ENGLISH_BUILD_VOCABULARY_PROMPT",
     "LIT_ANALYZE_TEXT_PROMPT",

--- a/config/expert_prompts.py
+++ b/config/expert_prompts.py
@@ -115,6 +115,34 @@ Teaching approach:
 
 Use appropriate literary terminology and cite sources when relevant.
 """,
+    "Math_Expert": """
+Special capabilities for Mathematics:
+- Solve algebra, geometry, calculus and statistics problems
+- Prove theorems using rigorous logic
+- Analyze functions and their properties
+- Work with numbers, vectors and matrices
+
+Problem-solving approach:
+1. Understand the problem and list knowns/unknowns
+2. Choose appropriate formulas or theorems
+3. Show derivation steps clearly
+4. Provide the final answer in simplest form
+5. Verify the result when possible
+""",
+    "Biology_Expert": """
+Special capabilities for Biology:
+- Explain cellular structures and functions
+- Describe genetic mechanisms and inheritance patterns
+- Analyze ecological interactions and evolutionary processes
+- Relate biological concepts to real-world applications
+
+Teaching approach:
+1. Start with concise definitions
+2. Use diagrams or analogies for clarity
+3. Connect concepts across biological scales
+4. Highlight practical examples
+5. Address common misconceptions
+""",
 }
 
 __all__ = ["EXPERT_PROMPTS"]

--- a/settings.py
+++ b/settings.py
@@ -3,6 +3,10 @@
 from dataclasses import dataclass, field
 from pathlib import Path
 import os
+from typing import Literal, cast
+
+
+HumanInputMode = Literal["ALWAYS", "NEVER", "TERMINATE"]
 
 
 @dataclass
@@ -19,7 +23,11 @@ class Settings:
     max_consecutive_auto_reply: int = field(
         default_factory=lambda: int(os.getenv("MAX_CONSECUTIVE_AUTO_REPLY", "3"))
     )
-    human_input_mode: str = field(default_factory=lambda: os.getenv("HUMAN_INPUT_MODE", "NEVER"))
+    human_input_mode: HumanInputMode = field(
+        default_factory=lambda: cast(
+            HumanInputMode, os.getenv("HUMAN_INPUT_MODE", "NEVER")
+        )
+    )
     data_path: Path = field(default_factory=lambda: Path(os.getenv("DATA_PATH", "data")))
     mongo_uri: str = field(
         default_factory=lambda: os.getenv("MONGO_URI", "mongodb://localhost:27017")


### PR DESCRIPTION
## Summary
- define `HumanInputMode` type to satisfy AssistantAgent constructor
- type SelectorGroupChat with `ConversableAgent` so user proxies can initiate chats
- add fully implemented MathExpertAgent and BiologyExpertAgent with supporting prompts

## Testing
- `python -m py_compile config/agents/base_agent.py settings.py chat/selector_group_chat.py config/agents/subject_experts/math_expert.py config/agents/subject_experts/biology_expert.py config/agents/subject_experts/prompts.py config/expert_prompts.py api/chat_controller.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68acdf6832bc8332b6ebe665fc8204bd