### PR TITLE
Fix type hint incompatibility in group chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,30 @@
+# Agent Service
+
+This project provides utilities for building multi-agent group chats powered by [AutoGen](https://github.com/microsoft/autogen). The `SelectorGroupChat` class allows conversations to dynamically route messages to the most relevant agent based on configurable selection strategies.
+
+## Installation
+
+```
+pip install -r requirements.txt
+```
+
+## Usage
+
+The `SelectorGroupChat` class can be used to create a group chat and manage agent selection:
+
+```python
+from chat.selector_group_chat import SelectorGroupChat
+
+chat = SelectorGroupChat([...])
+chat.start_chat("Hello")
+```
+
+## Testing
+
+Run type checking and tests:
+
+```
+mypy chat/selector_group_chat.py --ignore-missing-imports
+pytest
+```
+

--- a/chat/selector_group_chat.py
+++ b/chat/selector_group_chat.py
@@ -8,8 +8,10 @@ from typing import (
     Optional,
     Union,
     Literal,
+    Sequence,
+    cast,
 )
-from autogen import GroupChat, GroupChatManager, ConversableAgent
+from autogen import Agent, GroupChat, GroupChatManager, ConversableAgent
 from config.settings import settings
 from config.llm_config import LLMConfig
 from config.prompts import (
@@ -24,12 +26,12 @@ class SelectorGroupChat:
     
     def __init__(
         self,
-        agents: List[ConversableAgent],
+        agents: Sequence[ConversableAgent],
         max_rounds: Optional[int] = None,
         admin_name: str = "Admin",
         selection_method: str = "auto"  # auto, manual, or custom
     ):
-        self.agents = agents
+        self.agents: List[ConversableAgent] = list(agents)
         self.admin_name = admin_name
         self.selection_method = selection_method
         self.max_rounds = max_rounds or settings.max_rounds
@@ -43,7 +45,7 @@ class SelectorGroupChat:
     def _create_group_chat(self) -> GroupChat:
         """Create the group chat instance"""
         return GroupChat(
-            agents=self.agents,
+            agents=cast(List[Agent], self.agents),
             messages=[],
             max_round=self.max_rounds,
             speaker_selection_method=self._get_selection_method(),


### PR DESCRIPTION
## Summary
- fix type mismatch by using `Sequence` and casting when building `GroupChat`
- add project README with basic usage and test instructions

## Testing
- `mypy chat/selector_group_chat.py --ignore-missing-imports`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68ace23736d88332963ad04dad2f4e7d