### PR TITLE
Fix group chat agent typing and document run instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,22 @@ chat = SelectorGroupChat([...])
 chat.start_chat("Hello")
 ```
 
+## Running
+
+Start the FastAPI application to access the mock subject and chat endpoints:
+
+```
+uvicorn main:app --host 0.0.0.0 --port 8000
+```
+
+Alternatively, you can run the entrypoint directly:
+
+```
+python main.py
+```
+
+The API will be available at `http://localhost:8000` and interactive docs at `http://localhost:8000/docs`.
+
 ## Testing
 
 Run type checking and tests:

--- a/chat/selector_group_chat.py
+++ b/chat/selector_group_chat.py
@@ -145,14 +145,14 @@ class SelectorGroupChat:
     def add_agent(self, agent: ConversableAgent) -> None:
         """Add a new agent to the group chat"""
         self.agents.append(agent)
-        self.group_chat.agents = self.agents
+        self.group_chat.agents = cast(List[Agent], self.agents)
     
     def remove_agent(self, agent_name: str) -> bool:
         """Remove an agent from the group chat"""
         for i, agent in enumerate(self.agents):
             if agent.name == agent_name:
                 self.agents.pop(i)
-                self.group_chat.agents = self.agents
+                self.group_chat.agents = cast(List[Agent], self.agents)
                 return True
         return False
     


### PR DESCRIPTION
## Summary
- cast added/removed agents to `List[Agent]` when updating `GroupChat`
- document how to run the FastAPI application

## Testing
- `mypy chat/selector_group_chat.py --ignore-missing-imports`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68ace38f8c548332b1a096add94fc1e2