### PR TITLE
pass api key to llm config

### DIFF
--- a/config/llm_config.py
+++ b/config/llm_config.py
@@ -1,17 +1,14 @@
-"""
-Wrapper for LLM configuration utilities.
+"""Wrapper for LLM configuration utilities.
 
-This module re‑exports the :class:`LLMConfig` from the project root
-module :mod:`llm_config` so that code written for a package structure
-(``config.llm_config``) continues to function.  The real implementation
-of :class:`LLMConfig` resides in :mod:`llm_config` at the project root.
+This module re-exports the :class:`LLMConfig` from the project root module
+:mod:`llm_config` so that code written for a package structure
+(`config.llm_config`) continues to function. The real implementation of
+:class:`LLMConfig` resides in :mod:`llm_config` at the project root.
 """
 
 from __future__ import annotations
 
 from llm_config import LLMConfig  # noqa: F401
-
-from config.llm_config import LLMConfig
 
 LLMConfig.base_url = "https://mkp-api.fptcloud.com"
 

--- a/llm_config.py
+++ b/llm_config.py
@@ -13,6 +13,8 @@ class LLMConfig:
     default_model: str = "gpt-oss-120b"
     #: Optional base URL for the LLM API
     base_url: str = os.getenv("LLM_BASE_URL", "")
+    #: API key used to authenticate with the LLM provider
+    api_key: str = os.getenv("OPENAI_API_KEY", "")
     #: Mapping of agent names to the model they should use
     agent_models: Dict[str, str] = {}
 
@@ -33,6 +35,8 @@ class LLMConfig:
         }
         if cls.base_url:
             config["base_url"] = cls.base_url
+        if cls.api_key:
+            config["api_key"] = cls.api_key
         config.update(overrides)
         return config
 


### PR DESCRIPTION
## Summary
- include API key in LLM configuration so clients can authenticate with OpenAI or compatible endpoints
- clean up config.llm_config re-export to avoid circular import

## Testing
- `pytest`
- `python -m py_compile llm_config.py config/llm_config.py`


------
https://chatgpt.com/codex/tasks/task_b_68acebbd86c08332bfdc3082343eb60c