### PR TITLE
Allow runtime API key injection for group chat

### DIFF
--- a/api/chat_controller.py
+++ b/api/chat_controller.py
@@ -1,6 +1,6 @@
 """Endpoints enabling chat between a user and the team of agents."""
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Header
 from pydantic import BaseModel
 
 from chat.selector_group_chat import SelectorGroupChat
@@ -14,25 +14,39 @@ from config.agents import (
     LiteratureExpertAgent,
     InfoAgent,
 )
+from config.llm_config import LLMConfig
 
 router = APIRouter(prefix="/chat", tags=["chat"])
 
 
-def _build_group_chat() -> SelectorGroupChat:
+def _build_group_chat(api_key: str | None = None) -> SelectorGroupChat:
     agents = [
-        MathExpertAgent().get_agent(),
-        PhysicsExpertAgent().get_agent(),
-        ChemistryExpertAgent().get_agent(),
-        BiologyExpertAgent().get_agent(),
-        CSExpertAgent().get_agent(),
-        LiteratureExpertAgent().get_agent(),
-        EnglishExpertAgent().get_agent(),
-        InfoAgent().get_agent(),
+        MathExpertAgent(
+            llm_config=LLMConfig.get_expert_config("Math_Expert", api_key=api_key)
+        ).get_agent(),
+        PhysicsExpertAgent(
+            llm_config=LLMConfig.get_expert_config("Physics_Expert", api_key=api_key)
+        ).get_agent(),
+        ChemistryExpertAgent(
+            llm_config=LLMConfig.get_expert_config("Chemistry_Expert", api_key=api_key)
+        ).get_agent(),
+        BiologyExpertAgent(
+            llm_config=LLMConfig.get_expert_config("Biology_Expert", api_key=api_key)
+        ).get_agent(),
+        CSExpertAgent(
+            llm_config=LLMConfig.get_expert_config("CS_Expert", api_key=api_key)
+        ).get_agent(),
+        LiteratureExpertAgent(
+            llm_config=LLMConfig.get_expert_config("Literature_Expert", api_key=api_key)
+        ).get_agent(),
+        EnglishExpertAgent(
+            llm_config=LLMConfig.get_expert_config("English_Expert", api_key=api_key)
+        ).get_agent(),
+        InfoAgent(
+            llm_config=LLMConfig.get_agent_config("Info_Agent", api_key=api_key)
+        ).get_agent(),
     ]
-    return SelectorGroupChat(agents=agents)
-
-
-group_chat = _build_group_chat()
+    return SelectorGroupChat(agents=agents, api_key=api_key)
 
 
 class ChatRequest(BaseModel):
@@ -40,9 +54,13 @@ class ChatRequest(BaseModel):
 
 
 @router.post("/")
-async def chat_with_team(request: ChatRequest) -> dict:
+async def chat_with_team(
+    request: ChatRequest,
+    openai_api_key: str | None = Header(default=None, alias="OpenAI-Api-Key"),
+) -> dict:
     """Handle a user message and return the conversation history."""
     try:
+        group_chat = _build_group_chat(api_key=openai_api_key)
         group_chat.start_chat(request.message)
     except Exception as exc:  # pragma: no cover - runtime errors
         raise HTTPException(status_code=500, detail=str(exc)) from exc

--- a/chat/selector_group_chat.py
+++ b/chat/selector_group_chat.py
@@ -29,16 +29,18 @@ class SelectorGroupChat:
         agents: Sequence[ConversableAgent],
         max_rounds: Optional[int] = None,
         admin_name: str = "Admin",
-        selection_method: str = "auto"  # auto, manual, or custom
+        selection_method: str = "auto",  # auto, manual, or custom
+        api_key: str | None = None,
     ):
         self.agents: List[ConversableAgent] = list(agents)
         self.admin_name = admin_name
         self.selection_method = selection_method
         self.max_rounds = max_rounds or settings.max_rounds
-        
+        self.api_key = api_key
+
         # Create group chat
         self.group_chat = self._create_group_chat()
-        
+
         # Create group chat manager
         self.manager = self._create_manager()
     
@@ -54,8 +56,8 @@ class SelectorGroupChat:
     
     def _create_manager(self) -> GroupChatManager:
         """Create the group chat manager"""
-        manager_config = LLMConfig.get_config(temperature=0.3)
-        
+        manager_config = LLMConfig.get_config(temperature=0.3, api_key=self.api_key)
+
         return GroupChatManager(
             groupchat=self.group_chat,
             llm_config=manager_config,

--- a/llm_config.py
+++ b/llm_config.py
@@ -19,13 +19,21 @@ class LLMConfig:
     agent_models: Dict[str, str] = {}
 
     @classmethod
-    def get_config(cls, model: str | None = None, **overrides: Any) -> Dict[str, Any]:
+    def get_config(
+        cls,
+        model: str | None = None,
+        api_key: str | None = None,
+        **overrides: Any,
+    ) -> Dict[str, Any]:
         """Return a base configuration for the language model.
 
         Parameters
         ----------
         model:
             The model name to use. If ``None``, the class ``default_model`` is used.
+        api_key:
+            API key to use for this configuration. If ``None``, falls back to
+            :attr:`api_key`.
         **overrides:
             Additional configuration options to merge into the result.
         """
@@ -35,29 +43,40 @@ class LLMConfig:
         }
         if cls.base_url:
             config["base_url"] = cls.base_url
-        if cls.api_key:
-            config["api_key"] = cls.api_key
+        key = api_key or cls.api_key
+        if key:
+            config["api_key"] = key
         config.update(overrides)
         return config
 
     @classmethod
-    def get_agent_config(cls, agent_name: str, **overrides: Any) -> Dict[str, Any]:
+    def get_agent_config(
+        cls,
+        agent_name: str,
+        api_key: str | None = None,
+        **overrides: Any,
+    ) -> Dict[str, Any]:
         """Return configuration for a specific agent.
 
         This looks up ``agent_name`` in :attr:`agent_models` and falls back to
         :attr:`default_model` when no specific mapping is provided.
         """
         model = cls.agent_models.get(agent_name)
-        return cls.get_config(model=model, **overrides)
+        return cls.get_config(model=model, api_key=api_key, **overrides)
 
     @classmethod
-    def get_expert_config(cls, agent_name: str, **overrides: Any) -> Dict[str, Any]:
+    def get_expert_config(
+        cls,
+        agent_name: str,
+        api_key: str | None = None,
+        **overrides: Any,
+    ) -> Dict[str, Any]:
         """Return a configuration tuned for expert agents.
 
         Expert agents default to a slightly higher temperature for more
         detailed responses while still supporting per-agent model overrides.
         """
-        base = cls.get_agent_config(agent_name, temperature=0.2)
+        base = cls.get_agent_config(agent_name, api_key=api_key, temperature=0.2)
         base.update(overrides)
         return base
 


### PR DESCRIPTION
## Summary
- allow chat endpoint to accept `OpenAI-Api-Key` header
- propagate API key through `SelectorGroupChat` and LLM config

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_b_68aced37ac088332aad12a1680f7c689