### PR TITLE
feat: use OpenAI chat completion client

### DIFF
--- a/chat/selector_group_chat.py
+++ b/chat/selector_group_chat.py
@@ -11,7 +11,7 @@ from typing import (
     Sequence,
     cast,
 )
-from autogen import Agent, GroupChat, GroupChatManager, ConversableAgent
+from autogen import Agent, GroupChat, GroupChatManager, ConversableAgent, OpenAIChatCompletionClient
 from config.settings import settings
 from config.llm_config import LLMConfig
 from config.prompts import (
@@ -57,10 +57,11 @@ class SelectorGroupChat:
     def _create_manager(self) -> GroupChatManager:
         """Create the group chat manager"""
         manager_config = LLMConfig.get_config(temperature=0.3, api_key=self.api_key)
+        model_client = OpenAIChatCompletionClient(**manager_config)
 
         return GroupChatManager(
             groupchat=self.group_chat,
-            llm_config=manager_config,
+            model_client=model_client,
             system_message=GROUP_CHAT_MANAGER_PROMPT,
         )
     
@@ -133,8 +134,8 @@ class SelectorGroupChat:
             sender = UserProxyAgent(
                 name="User",
                 system_message=USER_PROXY_PROMPT,
-                llm_config=False,
-                human_input_mode="NEVER"
+                model_client=None,
+                human_input_mode="NEVER",
             )
         
         # Initiate the chat

--- a/config/agents/base_agent.py
+++ b/config/agents/base_agent.py
@@ -4,7 +4,7 @@ Base Agent class for all AutoGen agents
 from config.settings import settings
 from config.llm_config import LLMConfig
 from typing import Any, Dict, List, Optional, Literal, cast
-from autogen import AssistantAgent
+from autogen import AssistantAgent, OpenAIChatCompletionClient
 from config.prompts import SUBJECT_EXPERT_PROMPT_TEMPLATE
 
 HumanInputMode = Literal["ALWAYS", "NEVER", "TERMINATE"]
@@ -39,10 +39,11 @@ class BaseAgent:
     
     def _create_agent(self) -> AssistantAgent:
         """Create the AutoGen agent"""
+        model_client = OpenAIChatCompletionClient(**self.llm_config)
         return AssistantAgent(
             name=self.name,
             system_message=self.system_message,
-            llm_config=self.llm_config,
+            model_client=model_client,
             max_consecutive_auto_reply=self.max_consecutive_auto_reply,
             human_input_mode=self.human_input_mode,
         )


### PR DESCRIPTION
## Summary
- use `OpenAIChatCompletionClient` when creating assistant agents and group chat manager
- switch user proxy creation to new `model_client` parameter

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_b_68acf0856988833296fb42a9792a095a