### PR TITLE
Ensure default model_info for unknown models

### DIFF
--- a/llm_config.py
+++ b/llm_config.py
@@ -60,8 +60,16 @@ class LLMConfig:
         if key:
             config["api_key"] = key
         model_name = config["model"]
-        if model_name in cls.model_infos:
-            config["model_info"] = cls.model_infos[model_name]
+        # Ensure ``model_info`` is always populated for non-OpenAI models.
+        # ``OpenAIChatCompletionClient`` requires capability metadata when the
+        # model name is unknown to the service. We therefore fall back to the
+        # default model's information when the requested model lacks a
+        # dedicated entry.
+        config["model_info"] = (
+            cls.model_infos.get(model_name)
+            or cls.model_infos.get(cls.default_model)
+            or {}
+        )
         config.update(overrides)
         return config
 

--- a/tests/test_llm_config.py
+++ b/tests/test_llm_config.py
@@ -1,0 +1,37 @@
+"""Tests for the :mod:`llm_config` helper utilities."""
+
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from llm_config import LLMConfig  # type: ignore
+from autogen_core.models import ModelFamily
+
+
+def test_get_config_falls_back_to_default_model_info() -> None:
+    """Unknown models should reuse the default model's information."""
+    # Backup current configuration so the test is isolated.
+    original_default = LLMConfig.default_model
+    original_infos = LLMConfig.model_infos.copy()
+
+    try:
+        # Define a minimal default model info entry.
+        LLMConfig.default_model = "fallback-model"
+        LLMConfig.model_infos = {
+            "fallback-model": {
+                "vision": False,
+                "function_calling": False,
+                "json_output": False,
+                "structured_output": False,
+                "family": ModelFamily.UNKNOWN,
+            }
+        }
+
+        cfg = LLMConfig.get_config(model="custom-model")
+        assert cfg["model_info"] == LLMConfig.model_infos["fallback-model"]
+    finally:
+        # Restore original global state for any following tests.
+        LLMConfig.default_model = original_default
+        LLMConfig.model_infos = original_infos
+


### PR DESCRIPTION
## Summary
- always populate `model_info` in `LLMConfig.get_config`, falling back to the default model's info
- add regression test covering the fallback behaviour

## Testing
- `mypy chat/selector_group_chat.py --ignore-missing-imports`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68acf6f5488883329588ab40fd53822e