### PR TITLE
Improve OpenAI client guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,12 @@ This project provides utilities for building multi-agent group chats powered by 
 
 ## Installation
 
+
 ```
 pip install -r requirements.txt
+
+# Install the OpenAI extension for AutoGen
+pip install "autogen-ext[openai]"
 ```
 
 ## Usage

--- a/api/chat_controller.py
+++ b/api/chat_controller.py
@@ -14,37 +14,20 @@ from config.agents import (
     LiteratureExpertAgent,
     InfoAgent,
 )
-from config.llm_config import LLMConfig
 
 router = APIRouter(prefix="/chat", tags=["chat"])
 
 
 def _build_group_chat(api_key: str | None = None) -> SelectorGroupChat:
     agents = [
-        MathExpertAgent(
-            llm_config=LLMConfig.get_expert_config("Math_Expert", api_key=api_key)
-        ).get_agent(),
-        PhysicsExpertAgent(
-            llm_config=LLMConfig.get_expert_config("Physics_Expert", api_key=api_key)
-        ).get_agent(),
-        ChemistryExpertAgent(
-            llm_config=LLMConfig.get_expert_config("Chemistry_Expert", api_key=api_key)
-        ).get_agent(),
-        BiologyExpertAgent(
-            llm_config=LLMConfig.get_expert_config("Biology_Expert", api_key=api_key)
-        ).get_agent(),
-        CSExpertAgent(
-            llm_config=LLMConfig.get_expert_config("CS_Expert", api_key=api_key)
-        ).get_agent(),
-        LiteratureExpertAgent(
-            llm_config=LLMConfig.get_expert_config("Literature_Expert", api_key=api_key)
-        ).get_agent(),
-        EnglishExpertAgent(
-            llm_config=LLMConfig.get_expert_config("English_Expert", api_key=api_key)
-        ).get_agent(),
-        InfoAgent(
-            llm_config=LLMConfig.get_agent_config("Info_Agent", api_key=api_key)
-        ).get_agent(),
+        MathExpertAgent(api_key=api_key).get_agent(),
+        PhysicsExpertAgent(api_key=api_key).get_agent(),
+        ChemistryExpertAgent(api_key=api_key).get_agent(),
+        BiologyExpertAgent(api_key=api_key).get_agent(),
+        CSExpertAgent(api_key=api_key).get_agent(),
+        LiteratureExpertAgent(api_key=api_key).get_agent(),
+        EnglishExpertAgent(api_key=api_key).get_agent(),
+        InfoAgent(api_key=api_key).get_agent(),
     ]
     return SelectorGroupChat(agents=agents, api_key=api_key)
 

--- a/chat/selector_group_chat.py
+++ b/chat/selector_group_chat.py
@@ -13,11 +13,6 @@ from typing import (
 )
 from autogen import Agent, GroupChat, GroupChatManager, ConversableAgent
 from inspect import signature
-
-try:  # pragma: no cover - optional dependency
-    from autogen_ext.models.openai import OpenAIChatCompletionClient
-except Exception:  # pragma: no cover
-    OpenAIChatCompletionClient = None  # type: ignore
 from config.settings import settings
 from config.llm_config import LLMConfig
 from config.prompts import (
@@ -63,11 +58,9 @@ class SelectorGroupChat:
     def _create_manager(self) -> GroupChatManager:
         """Create the group chat manager"""
         manager_config = LLMConfig.get_config(temperature=0.3, api_key=self.api_key)
-        if OpenAIChatCompletionClient is None:
-            raise RuntimeError("OpenAIChatCompletionClient is required")
         if "model_client" not in signature(GroupChatManager.__init__).parameters:
             raise RuntimeError("This AutoGen version lacks model_client support")
-        model_client = OpenAIChatCompletionClient(**manager_config)
+        model_client = LLMConfig.build_model_client(manager_config)
         return GroupChatManager(
             groupchat=self.group_chat,
             model_client=model_client,

--- a/llm_config.py
+++ b/llm_config.py
@@ -15,6 +15,11 @@ except Exception:  # pragma: no cover - fallback when autogen_core is missing
 
         UNKNOWN = "unknown"
 
+try:  # pragma: no cover - optional dependency
+    from autogen_ext.models.openai import OpenAIChatCompletionClient
+except Exception:  # pragma: no cover - autogen-ext may not be installed
+    OpenAIChatCompletionClient = None  # type: ignore
+
 
 class LLMConfig:
     """Utility helpers to construct LLM configuration dictionaries."""
@@ -113,6 +118,20 @@ class LLMConfig:
         base = cls.get_agent_config(agent_name, api_key=api_key, **overrides)
         base["temperature"] = temp
         return base
+
+    @staticmethod
+    def build_model_client(config: Dict[str, Any]):
+        """Instantiate the OpenAI chat completion client.
+
+        Centralises the import of :class:`OpenAIChatCompletionClient` so that
+        callers need not handle the optional dependency themselves.
+        """
+        if OpenAIChatCompletionClient is None:
+            raise RuntimeError(
+                "OpenAIChatCompletionClient is required. "
+                "Install it with 'pip install \"autogen-ext[openai]\"'.",
+            )
+        return OpenAIChatCompletionClient(**config)
 
 
 __all__ = ["LLMConfig"]


### PR DESCRIPTION
## Summary
- centralize OpenAIChatCompletionClient creation in LLMConfig
- simplify agent initialization and controller wiring with optional API key

## Testing
- `mypy chat/selector_group_chat.py --ignore-missing-imports`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68ad30f8af148332b1938de2d46d5f2f