### PR TITLE
feat: add legacy autogen fallback

### DIFF
--- a/config/agents/base_agent.py
+++ b/config/agents/base_agent.py
@@ -56,13 +56,26 @@ class BaseAgent:
     
     def _create_agent(self) -> AssistantAgent:
         """Create the AutoGen agent"""
-        if "model_client" not in signature(AssistantAgent.__init__).parameters:
-            raise RuntimeError("This AutoGen version lacks model_client support")
-        model_client = LLMConfig.build_model_client(self.llm_config)
+        params = signature(AssistantAgent.__init__).parameters
+        if "model_client" in params:
+            cfg = dict(self.llm_config)
+            model_client = cfg.pop("model_client", None)
+            if model_client is None:
+                model_client = LLMConfig.build_model_client(cfg)
+            return AssistantAgent(
+                name=self.name,
+                system_message=self.system_message,
+                model_client=model_client,
+                max_consecutive_auto_reply=self.max_consecutive_auto_reply,
+                human_input_mode=self.human_input_mode,
+            )
+        # Fallback for older AutoGen versions that expect ``llm_config``
+        cfg = dict(self.llm_config)
+        cfg.pop("model_client", None)
         return AssistantAgent(
             name=self.name,
             system_message=self.system_message,
-            model_client=model_client,
+            llm_config=cfg,
             max_consecutive_auto_reply=self.max_consecutive_auto_reply,
             human_input_mode=self.human_input_mode,
         )


### PR DESCRIPTION
## Summary
- fallback to llm_config when model_client isn't supported
- build OpenAIChatCompletionClient when available
- respect provided model_client inside llm_config

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68ad396f75f88332bbd8ea2c0745132b