### PR TITLE
refactor: consolidate config helpers

### DIFF
--- a/chat/selector_group_chat.py
+++ b/chat/selector_group_chat.py
@@ -51,7 +51,9 @@ class SelectorGroupChat:
     
     def _create_manager(self) -> GroupChatManager:
         """Create the group chat manager"""
-        manager_config = LLMConfig.get_config(temperature=0.3, api_key=self.api_key)
+        manager_config = LLMConfig.get_agent_config(
+            "group_chat_manager", temperature=0.3, api_key=self.api_key
+        )
         params = signature(GroupChatManager.__init__).parameters
         if "model_client" in params:
             cfg = dict(manager_config)

--- a/llm_config.py
+++ b/llm_config.py
@@ -46,48 +46,6 @@ class LLMConfig:
     }
 
     @classmethod
-    def get_config(
-        cls,
-        model: str | None = None,
-        api_key: str | None = None,
-        **overrides: Any,
-    ) -> Dict[str, Any]:
-        """Return a base configuration for the language model.
-
-        Parameters
-        ----------
-        model:
-            The model name to use. If ``None``, the class ``default_model`` is used.
-        api_key:
-            API key to use for this configuration. If ``None``, falls back to
-            :attr:`api_key`.
-        **overrides:
-            Additional configuration options to merge into the result.
-        """
-        config: Dict[str, Any] = {
-            "model": model or cls.default_model,
-            "temperature": 0,
-        }
-        if cls.base_url:
-            config["base_url"] = cls.base_url
-        key = api_key or cls.api_key
-        if key:
-            config["api_key"] = key
-        model_name = config["model"]
-        # Ensure ``model_info`` is always populated for non-OpenAI models.
-        # ``OpenAIChatCompletionClient`` requires capability metadata when the
-        # model name is unknown to the service. We therefore fall back to the
-        # default model's information when the requested model lacks a
-        # dedicated entry.
-        config["model_info"] = (
-            cls.model_infos.get(model_name)
-            or cls.model_infos.get(cls.default_model)
-            or {}
-        )
-        config.update(overrides)
-        return config
-
-    @classmethod
     def get_agent_config(
         cls,
         agent_name: str,
@@ -96,11 +54,30 @@ class LLMConfig:
     ) -> Dict[str, Any]:
         """Return configuration for a specific agent.
 
-        This looks up ``agent_name`` in :attr:`agent_models` and falls back to
-        :attr:`default_model` when no specific mapping is provided.
+        This first resolves the model for the given ``agent_name`` and then
+        constructs the base configuration, ensuring required metadata like
+        ``model_info`` is always included. If ``agent_name`` is not mapped in
+        :attr:`agent_models`, the :attr:`default_model` is used.
         """
-        model = overrides.pop("model", cls.agent_models.get(agent_name))
-        return cls.get_config(model=model, api_key=api_key, **overrides)
+        model = overrides.pop(
+            "model", cls.agent_models.get(agent_name) or cls.default_model
+        )
+        config: Dict[str, Any] = {
+            "model": model,
+            "temperature": 0,
+        }
+        if cls.base_url:
+            config["base_url"] = cls.base_url
+        key = api_key or cls.api_key
+        if key:
+            config["api_key"] = key
+        config["model_info"] = (
+            cls.model_infos.get(model)
+            or cls.model_infos.get(cls.default_model)
+            or {}
+        )
+        config.update(overrides)
+        return config
 
     @classmethod
     def get_expert_config(

--- a/tests/test_llm_config.py
+++ b/tests/test_llm_config.py
@@ -9,7 +9,7 @@ from llm_config import LLMConfig  # type: ignore
 from autogen_core.models import ModelFamily
 
 
-def test_get_config_falls_back_to_default_model_info() -> None:
+def test_get_agent_config_falls_back_to_default_model_info() -> None:
     """Unknown models should reuse the default model's information."""
     # Backup current configuration so the test is isolated.
     original_default = LLMConfig.default_model
@@ -28,7 +28,7 @@ def test_get_config_falls_back_to_default_model_info() -> None:
             }
         }
 
-        cfg = LLMConfig.get_config(model="custom-model")
+        cfg = LLMConfig.get_agent_config("dummy", model="custom-model")
         assert cfg["model_info"] == LLMConfig.model_infos["fallback-model"]
     finally:
         # Restore original global state for any following tests.


### PR DESCRIPTION
## Summary
- remove generic `get_config` helper and fold logic into `get_agent_config`
- update chat manager and tests to use `get_agent_config`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68ad3c05c4108332bebada4a5f78af55