### PR TITLE
refactor: consolidate config helpers

### DIFF
--- a/chat/selector_group_chat.py
+++ b/chat/selector_group_chat.py
@@ -51,11 +51,14 @@ class SelectorGroupChat:
     
     def _create_manager(self) -> GroupChatManager:
         """Create the group chat manager"""
-        manager_config = LLMConfig.get_config(temperature=0.3, api_key=self.api_key)
+        manager_config = LLMConfig.get_agent_config(
+            "group_chat_manager", temperature=0.3, api_key=self.api_key
+        )
         params = signature(GroupChatManager.__init__).parameters
         if "model_client" in params:
             cfg = dict(manager_config)
             model_client = cfg.pop("model_client", None)
+            cfg.pop("model_info", None)
             if model_client is None:
                 model_client = LLMConfig.build_model_client(cfg)
             return GroupChatManager(
@@ -66,6 +69,7 @@ class SelectorGroupChat:
         # Older AutoGen versions rely on ``llm_config`` directly
         cfg = dict(manager_config)
         cfg.pop("model_client", None)
+        cfg.pop("model_info", None)
         return GroupChatManager(
             groupchat=self.group_chat,
             llm_config=cfg,

--- a/config/agents/base_agent.py
+++ b/config/agents/base_agent.py
@@ -60,6 +60,7 @@ class BaseAgent:
         if "model_client" in params:
             cfg = dict(self.llm_config)
             model_client = cfg.pop("model_client", None)
+            cfg.pop("model_info", None)
             if model_client is None:
                 model_client = LLMConfig.build_model_client(cfg)
             return AssistantAgent(
@@ -72,6 +73,7 @@ class BaseAgent:
         # Fallback for older AutoGen versions that expect ``llm_config``
         cfg = dict(self.llm_config)
         cfg.pop("model_client", None)
+        cfg.pop("model_info", None)
         return AssistantAgent(
             name=self.name,
             system_message=self.system_message,
@@ -120,8 +122,9 @@ class SubjectExpertAgent(BaseAgent):
             overrides = raw_cfg
         else:
             overrides = {}
-        llm_config = LLMConfig.get_expert_config(
-            name, api_key=api_key, **overrides
+        temp = overrides.pop("temperature", 0.2)
+        llm_config = LLMConfig.get_agent_config(
+            name, api_key=api_key, temperature=temp, **overrides
         )
 
         super().__init__(

--- a/tests/test_llm_config.py
+++ b/tests/test_llm_config.py
@@ -5,11 +5,12 @@ import sys
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
+import llm_config
 from llm_config import LLMConfig  # type: ignore
 from autogen_core.models import ModelFamily
 
 
-def test_get_config_falls_back_to_default_model_info() -> None:
+def test_get_agent_config_falls_back_to_default_model_info() -> None:
     """Unknown models should reuse the default model's information."""
     # Backup current configuration so the test is isolated.
     original_default = LLMConfig.default_model
@@ -28,10 +29,23 @@ def test_get_config_falls_back_to_default_model_info() -> None:
             }
         }
 
-        cfg = LLMConfig.get_config(model="custom-model")
+        cfg = LLMConfig.get_agent_config("dummy", model="custom-model")
         assert cfg["model_info"] == LLMConfig.model_infos["fallback-model"]
     finally:
         # Restore original global state for any following tests.
         LLMConfig.default_model = original_default
         LLMConfig.model_infos = original_infos
+
+
+def test_build_model_client_strips_model_info(monkeypatch) -> None:
+    """``model_info`` should not be forwarded to the client."""
+    class DummyClient:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    monkeypatch.setattr(llm_config, "OpenAIChatCompletionClient", DummyClient)
+    cfg = LLMConfig.get_agent_config("dummy")
+    client = LLMConfig.build_model_client(cfg)
+    assert isinstance(client, DummyClient)
+    assert "model_info" not in client.kwargs
 


### PR DESCRIPTION
## Summary
- filter model_info before creating OpenAI clients to avoid unexpected keyword errors
- remove get_expert_config in favor of get_agent_config with an overridable temperature
- update agents and group chat manager accordingly and add regression test

## Testing
- `pytest`
- `mypy chat/selector_group_chat.py --ignore-missing-imports`


------
https://chatgpt.com/codex/tasks/task_b_68ad3c05c4108332bebada4a5f78af55