### PR TITLE
Gracefully handle ChatResult return value

### DIFF
--- a/api/chat_controller.py
+++ b/api/chat_controller.py
@@ -78,6 +78,17 @@ async def chat_endpoint(payload: ChatRequest) -> ChatResponse:
         max_rounds=payload.max_rounds,
     )
 
+    if not isinstance(result, str):
+        if getattr(result, "summary", None):
+            result = result.summary  # type: ignore[assignment]
+        elif getattr(result, "chat_history", None):
+            try:
+                result = result.chat_history[-1].get("content", "")  # type: ignore[index]
+            except Exception:
+                result = str(result)
+        else:
+            result = str(result)
+
     return ChatResponse(result=result)
 
 


### PR DESCRIPTION
## Summary
- Normalize `initiate_group_chat` outputs to strings before constructing `ChatResponse`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68af52dd84348332aaf127753584cbb6