### PR TITLE
Refactor team builder for flexible agent configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,18 @@ LLMConfig.agent_models = {
 }
 ```
 
+The ``create_team`` helper reads connection details from environment variables
+to simplify configuration:
+
+```bash
+export LLM_API_KEY="sk-..."
+export LLM_BASE_URL="https://mkp-api.fptcloud.com"
+export LLM_MODEL="gpt-oss-120b"
+```
+
+You can override these defaults by passing ``api_key``, ``base_url``, ``model``
+or custom ``context_data`` directly to :code:`create_team`.
+
 Agents without an explicit entry fall back to ``LLMConfig.default_model``.
 When using non-OpenAI model names, the underlying
 ``OpenAIChatCompletionClient`` requires a ``model_info`` dictionary describing

--- a/api/team_builder.py
+++ b/api/team_builder.py
@@ -1,13 +1,15 @@
 """Create groups of conversational agents and run demo chats."""
 
+from __future__ import annotations
+
+import os
+from typing import Dict, List, Optional
+
 from .agent_base import (
-    initiate_group_chat,
     ContextVariables,
-    AutoPattern,
     ConversableAgent,
     AssistantAgent,
     LLMConfig,
-    logger,
 )
 from .prompts import (
     build_subject_system_message,
@@ -17,139 +19,167 @@ from .prompts import (
 from .personalization import make_personalization_updater, chain_updaters
 
 
-def create_team(model: str = "gpt-oss-120b", temperature: float = 0.2):
-    """Trả về (agents_list, user_agent, group_manager_args, context_variables)."""
+DEFAULT_CONTEXT: Dict[str, str] = {
+    "language": "vi",
+    "student_level": "HS phổ thông",
+    "curriculum": "VN K-12",
+    "goals": "Hiểu sâu khái niệm và làm bài tập có hướng dẫn",
+}
 
-    llm_config = {
-        "config_list": [{"model": model, "api_key": "sk-SGFmxZPAP8mk5P-aEm3v9Q", "base_url": "https://mkp-api.fptcloud.com"}],
-        "temperature": temperature
-    }
 
-    llm_config = LLMConfig(config_list=llm_config["config_list"], temperature=llm_config["temperature"])
+def _make_expert_agent(
+    name: str, subject: str, expertise: List[str], description: str
+) -> AssistantAgent:
+    """Build a subject expert agent with common defaults."""
 
-    context = ContextVariables(
-        data={
-            "language": "vi",
-            "student_level": "HS phổ thông",
-            "curriculum": "VN K-12",
-            "goals": "Hiểu sâu khái niệm và làm bài tập có hướng dẫn",
-        }
+    agent = AssistantAgent(
+        name=name,
+        system_message=build_subject_system_message(subject, expertise, name),
+        human_input_mode="NEVER",
+    )
+    agent.description = description
+    return agent
+
+
+EXPERT_DEFINITIONS: List[Dict[str, object]] = [
+    {
+        "name": "CS_Expert",
+        "subject": "Computer Science",
+        "expertise": [
+            "Programming (Python, Java, C++, JavaScript)",
+            "Data Structures (Arrays, Trees, Graphs, Hash Tables)",
+            "Algorithms (Sorting, Searching, Dynamic Programming)",
+            "Software Engineering (Design Patterns, Testing, Agile)",
+            "Databases (SQL, NoSQL, Design)",
+            "Operating Systems",
+            "Computer Networks",
+            "AI/ML",
+            "Web Development",
+        ],
+        "description": (
+            "Answers programming/CS questions; writes & debugs code; algorithms; systems; "
+            "databases; networks."
+        ),
+    },
+    {
+        "name": "Math_Expert",
+        "subject": "Mathematics",
+        "expertise": ["Algebra", "Geometry", "Calculus", "Statistics", "Linear Algebra"],
+        "description": (
+            "Solves math problems step-by-step; proofs; functions; calculus; statistics."
+        ),
+    },
+    {
+        "name": "English_Expert",
+        "subject": "English Language",
+        "expertise": [
+            "Grammar",
+            "Vocabulary",
+            "Pronunciation",
+            "IELTS/TOEFL",
+            "Writing/Listening/Speaking",
+        ],
+        "description": (
+            "English language instruction: grammar, IELTS/TOEFL, pronunciation, writing feedback."
+        ),
+    },
+    {
+        "name": "Biology_Expert",
+        "subject": "Biology",
+        "expertise": ["Cell biology", "Genetics", "Ecology", "Evolution", "Physiology"],
+        "description": (
+            "Explains biology: cells, genetics, ecology, evolution; clear analogies."
+        ),
+    },
+    {
+        "name": "Physics_Expert",
+        "subject": "Physics",
+        "expertise": [
+            "Mechanics",
+            "Electricity & Magnetism",
+            "Waves",
+            "Thermodynamics",
+            "Modern Physics",
+        ],
+        "description": (
+            "Solves physics problems; diagrams; derivations; unit analysis; conceptual clarity."
+        ),
+    },
+    {
+        "name": "Chemistry_Expert",
+        "subject": "Chemistry",
+        "expertise": [
+            "Stoichiometry",
+            "Thermochemistry",
+            "Equilibrium",
+            "Organic",
+            "Inorganic",
+            "Spectroscopy",
+        ],
+        "description": (
+            "Chemistry problem solving: equations, mechanisms, yields, structures, "
+            "spectroscopic reasoning."
+        ),
+    },
+    {
+        "name": "Literature_Expert",
+        "subject": "Literature",
+        "expertise": [
+            "Close reading",
+            "Themes/Motifs",
+            "Comparative analysis",
+            "Essay guidance",
+            "Literary devices",
+        ],
+        "description": (
+            "Analyzes literature; historical context; writing guidance; literary devices."
+        ),
+    },
+]
+
+
+def create_team(
+    model: Optional[str] = None,
+    temperature: float = 0.2,
+    context_data: Optional[Dict[str, str]] = None,
+    api_key: Optional[str] = None,
+    base_url: Optional[str] = None,
+):
+    """Return (agents_list, user_agent, group_manager_args, context_variables)."""
+
+    model = model or os.getenv("LLM_MODEL", "gpt-oss-120b")
+    api_key = api_key or os.getenv("LLM_API_KEY", "")
+    base_url = base_url or os.getenv(
+        "LLM_BASE_URL", "https://mkp-api.fptcloud.com"
     )
 
+    llm_config = LLMConfig(
+        config_list=[{"model": model, "api_key": api_key, "base_url": base_url}],
+        temperature=temperature,
+    )
+
+    context_values = {**DEFAULT_CONTEXT, **(context_data or {})}
+    context = ContextVariables(data=context_values)
+
     with llm_config:
-        # Info agent
         info_agent = AssistantAgent(
             name="Info_Agent",
             system_message=INFO_AGENT_PROMPT,
             human_input_mode="NEVER",
         )
-        info_agent.description = "Curates curricula and learning materials; generates practice questions; routes resources."
-
-        # Subject experts
-        cs_expert = AssistantAgent(
-            name="CS_Expert",
-            system_message=build_subject_system_message(
-                "Computer Science",
-                [
-                    "Programming (Python, Java, C++, JavaScript)",
-                    "Data Structures (Arrays, Trees, Graphs, Hash Tables)",
-                    "Algorithms (Sorting, Searching, Dynamic Programming)",
-                    "Software Engineering (Design Patterns, Testing, Agile)",
-                    "Databases (SQL, NoSQL, Design)",
-                    "Operating Systems",
-                    "Computer Networks",
-                    "AI/ML",
-                    "Web Development",
-                ],
-                "CS_Expert",
-            ),
-            human_input_mode="NEVER",
+        info_agent.description = (
+            "Curates curricula and learning materials; generates practice questions; "
+            "routes resources."
         )
-        cs_expert.description = "Answers programming/CS questions; writes & debugs code; algorithms; systems; databases; networks."
 
-        math_expert = AssistantAgent(
-            name="Math_Expert",
-            system_message=build_subject_system_message(
-                "Mathematics",
-                ["Algebra", "Geometry", "Calculus", "Statistics", "Linear Algebra"],
-                "Math_Expert",
-            ),
-            human_input_mode="NEVER",
-        )
-        math_expert.description = "Solves math problems step-by-step; proofs; functions; calculus; statistics."
+        subject_agents = [_make_expert_agent(**cfg) for cfg in EXPERT_DEFINITIONS]
 
-        eng_expert = AssistantAgent(
-            name="English_Expert",
-            system_message=build_subject_system_message(
-                "English Language",
-                ["Grammar", "Vocabulary", "Pronunciation", "IELTS/TOEFL", "Writing/Listening/Speaking"],
-                "English_Expert",
-            ),
-            human_input_mode="NEVER",
-        )
-        eng_expert.description = "English language instruction: grammar, IELTS/TOEFL, pronunciation, writing feedback."
-
-        bio_expert = AssistantAgent(
-            name="Biology_Expert",
-            system_message=build_subject_system_message(
-                "Biology",
-                ["Cell biology", "Genetics", "Ecology", "Evolution", "Physiology"],
-                "Biology_Expert",
-            ),
-            human_input_mode="NEVER",
-        )
-        bio_expert.description = "Explains biology: cells, genetics, ecology, evolution; clear analogies."
-
-        phy_expert = AssistantAgent(
-            name="Physics_Expert",
-            system_message=build_subject_system_message(
-                "Physics",
-                ["Mechanics", "Electricity & Magnetism", "Waves", "Thermodynamics", "Modern Physics"],
-                "Physics_Expert",
-            ),
-            human_input_mode="NEVER",
-        )
-        phy_expert.description = "Solves physics problems; diagrams; derivations; unit analysis; conceptual clarity."
-
-        chem_expert = AssistantAgent(
-            name="Chemistry_Expert",
-            system_message=build_subject_system_message(
-                "Chemistry",
-                ["Stoichiometry", "Thermochemistry", "Equilibrium", "Organic", "Inorganic", "Spectroscopy"],
-                "Chemistry_Expert",
-            ),
-            human_input_mode="NEVER",
-        )
-        chem_expert.description = "Chemistry problem solving: equations, mechanisms, yields, structures, spectroscopic reasoning."
-
-        lit_expert = AssistantAgent(
-            name="Literature_Expert",
-            system_message=build_subject_system_message(
-                "Literature",
-                ["Close reading", "Themes/Motifs", "Comparative analysis", "Essay guidance", "Literary devices"],
-                "Literature_Expert",
-            ),
-            human_input_mode="NEVER",
-        )
-        lit_expert.description = "Analyzes literature; historical context; writing guidance; literary devices."
-
-        # Create and assign per-agent updater with correct signature
-        all_agents = [
-            info_agent,
-            cs_expert,
-            math_expert,
-            eng_expert,
-            bio_expert,
-            phy_expert,
-            chem_expert,
-            lit_expert,
-        ]
+        all_agents = [info_agent, *subject_agents]
         for agent in all_agents:
             personalizer = make_personalization_updater(agent, context)
             updater_callable = chain_updaters(personalizer)
             setattr(agent, "update_agent_state_before_reply", updater_callable)
 
-        # User agent đại diện cho học sinh
         user_agent = ConversableAgent(
             name="student",
             human_input_mode="NEVER",
@@ -163,4 +193,6 @@ def create_team(model: str = "gpt-oss-120b", temperature: float = 0.2):
 
     return all_agents, user_agent, group_manager_args, context
 
+
 __all__ = ["create_team"]
+


### PR DESCRIPTION
## Summary
- Build subject experts from a shared configuration and helper
- Source model credentials and context from environment variables in `create_team`
- Document environment variables for configuring `create_team`

## Testing
- `python -m py_compile api/team_builder.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68af54d1efd48332b4f80197bdca44dd